### PR TITLE
Allow specification of schema in postgres connection url

### DIFF
--- a/driver/postgres/README.md
+++ b/driver/postgres/README.md
@@ -14,8 +14,8 @@ migrate -url postgres://user@host:port/database -path ./db/migrations create add
 migrate -url postgres://user@host:port/database -path ./db/migrations up
 migrate help # for more info
 
-# TODO(mattes): thinking about adding some custom flag to allow migration within schemas:
--url="postgres://user@host:port/database?schema=name" 
+# specify the schema within the database to perform migrations using below query string syntax
+-url="postgres://user@host:port/database?schema=name"
 ```
 
 ## Authors

--- a/driver/postgres/postgres.go
+++ b/driver/postgres/postgres.go
@@ -40,7 +40,7 @@ func (driver *Driver) Initialize(connUrl string) error {
 
 	if schemaName != "" {
 		// use search_path for backwards compatibility to postgres 8ish
-		if _, err := db.Exec("SET search_path TO '$1';", schemaName); err != nil {
+		if _, err := db.Exec("SET search_path TO " + pq.QuoteIdentifier(schemaName) + ";"); err != nil {
 			return err
 		}
 	}

--- a/driver/postgres/postgres_test.go
+++ b/driver/postgres/postgres_test.go
@@ -95,3 +95,7 @@ func TestMigrate(t *testing.T) {
 		t.Fatal(err)
 	}
 }
+
+func TestMigrateWithinSpecificSchema(t *testing.T) {
+	t.Error("TODO write this test")
+}


### PR DESCRIPTION
Didn't mean to submit it upstream quite just yet (whoops https://github.com/mattes/migrate/pull/110)

Trying to get migrations working for our redshift, need to specify both database and schema in a compatible way with redshift
